### PR TITLE
Update the text `This issue is ready`

### DIFF
--- a/.github/ISSUE_TEMPLATE/101-deliverable.yml
+++ b/.github/ISSUE_TEMPLATE/101-deliverable.yml
@@ -3,50 +3,50 @@ description: "⚠️ For Project Maintainers: Create a Deliverable work item"
 type: "Deliverable"
 labels: ["🚦 triage"]
 body:
-- type: checkboxes
-  attributes:
-    label: Is this the right issue type?
-    description: "If you're not involved in work planning for this project, you're probably in the wrong place."
-    options:
-    - label: "Yes, I'm planning work for this project team."
+  - type: checkboxes
+    attributes:
+      label: Is this the right issue type?
+      description: "If you're not involved in work planning for this project, you're probably in the wrong place."
+      options:
+        - label: "Yes, I'm planning work for this project team."
+          required: true
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        A short description of the work item
+    validations:
       required: true
-- type: textarea
-  attributes:
-    label: Summary
-    description: |
-      A short description of the work item
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Acceptance Criteria
-    description: A breakdown of acceptance criteria to determine this work item's definition of done.
-    value: |
-      - [ ] Criterion A is met.
-      - [ ] Criterion B is met.
-      - [ ] Tests pass.
-      - [ ] Documentation added.
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Tasks
-    description: A breakdown of tasks required to meet the acceptance criteria.
-    value: |
-      - [ ] Task A.
-      - [ ] Task B.
-      - [ ] Unit tests.
-      - [ ] Documentation.
-  validations:
-    required: true
-- type: checkboxes
-  attributes:
-    label: Confirm creation
-    description: |
-      Don't forget:
-        - Link a parent issue
-        - Add to Projects and set metadata
-        - Add to milestones
-    options:
-    - label: "This issue is ready"
+  - type: textarea
+    attributes:
+      label: Acceptance Criteria
+      description: A breakdown of acceptance criteria to determine this work item's definition of done.
+      value: |
+        - [ ] Criterion A is met.
+        - [ ] Criterion B is met.
+        - [ ] Tests pass.
+        - [ ] Documentation added.
+    validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Tasks
+      description: A breakdown of tasks required to meet the acceptance criteria.
+      value: |
+        - [ ] Task A.
+        - [ ] Task B.
+        - [ ] Unit tests.
+        - [ ] Documentation.
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Confirm creation
+      description: |
+        Don't forget:
+          - Link a parent issue
+          - Add to Projects and set metadata
+          - Add to milestones
+      options:
+        - label: "Ready to create this deliverable"
+          required: true

--- a/.github/ISSUE_TEMPLATE/101-deliverable.yml
+++ b/.github/ISSUE_TEMPLATE/101-deliverable.yml
@@ -48,5 +48,5 @@ body:
           - Add to Projects and set metadata
           - Add to milestones
       options:
-        - label: "Ready to create this deliverable"
+        - label: "Ready to create this deliverable?"
           required: true

--- a/.github/ISSUE_TEMPLATE/102-feature.yml
+++ b/.github/ISSUE_TEMPLATE/102-feature.yml
@@ -37,5 +37,5 @@ body:
           - Add to Projects and set metadata
           - Add to milestones
       options:
-        - label: "Ready to create this feature"
+        - label: "Ready to create this feature?"
           required: true

--- a/.github/ISSUE_TEMPLATE/102-feature.yml
+++ b/.github/ISSUE_TEMPLATE/102-feature.yml
@@ -3,39 +3,39 @@ description: "⚠️ For Project Maintainers: Create a Feature work item"
 type: "Feature"
 labels: ["🚦 triage"]
 body:
-- type: checkboxes
-  attributes:
-    label: Is this the right issue type?
-    description: "If you're not involved in work planning for this project, you're probably in the wrong place."
-    options:
-    - label: "Yes, I'm planning work for this project team."
+  - type: checkboxes
+    attributes:
+      label: Is this the right issue type?
+      description: "If you're not involved in work planning for this project, you're probably in the wrong place."
+      options:
+        - label: "Yes, I'm planning work for this project team."
+          required: true
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        A short description of the work item
+    validations:
       required: true
-- type: textarea
-  attributes:
-    label: Summary
-    description: |
-      A short description of the work item
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Acceptance Criteria
-    description: A breakdown of acceptance criteria to determine this work item's definition of done.
-    value: |
-      - [ ] Criterion A is met.
-      - [ ] Criterion B is met.
-      - [ ] Tests pass.
-      - [ ] Documentation added.
-  validations:
-    required: true
-- type: checkboxes
-  attributes:
-    label: Confirm creation
-    description: |
-      Don't forget:
-        - Link a parent issue
-        - Add to Projects and set metadata
-        - Add to milestones
-    options:
-    - label: "This issue is ready"
+  - type: textarea
+    attributes:
+      label: Acceptance Criteria
+      description: A breakdown of acceptance criteria to determine this work item's definition of done.
+      value: |
+        - [ ] Criterion A is met.
+        - [ ] Criterion B is met.
+        - [ ] Tests pass.
+        - [ ] Documentation added.
+    validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: Confirm creation
+      description: |
+        Don't forget:
+          - Link a parent issue
+          - Add to Projects and set metadata
+          - Add to milestones
+      options:
+        - label: "Ready to create this feature"
+          required: true

--- a/.github/ISSUE_TEMPLATE/103-epic.yml
+++ b/.github/ISSUE_TEMPLATE/103-epic.yml
@@ -23,5 +23,5 @@ body:
         Don't forget:
           - Add to Projects and set metadata
       options:
-        - label: "Ready to create this epic"
+        - label: "Ready to create this epic?"
           required: true

--- a/.github/ISSUE_TEMPLATE/103-epic.yml
+++ b/.github/ISSUE_TEMPLATE/103-epic.yml
@@ -2,26 +2,26 @@ name: 🔶 Epic
 description: "⚠️ For Project Maintainers: Create an Epic work item"
 type: "Epic"
 body:
-- type: checkboxes
-  attributes:
-    label: Is this the right issue type?
-    description: "If you're not involved in work planning for this project, you're probably in the wrong place."
-    options:
-    - label: "Yes, I'm planning work for this project team."
+  - type: checkboxes
+    attributes:
+      label: Is this the right issue type?
+      description: "If you're not involved in work planning for this project, you're probably in the wrong place."
+      options:
+        - label: "Yes, I'm planning work for this project team."
+          required: true
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        A short description of the work item
+    validations:
       required: true
-- type: textarea
-  attributes:
-    label: Summary
-    description: |
-      A short description of the work item
-  validations:
-    required: true
-- type: checkboxes
-  attributes:
-    label: Confirm creation
-    description: |
-      Don't forget:
-        - Add to Projects and set metadata
-    options:
-    - label: "This issue is ready"
-      required: true
+  - type: checkboxes
+    attributes:
+      label: Confirm creation
+      description: |
+        Don't forget:
+          - Add to Projects and set metadata
+      options:
+        - label: "Ready to create this epic"
+          required: true


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🛠️ Repo maintenance

## PR Description
The text `This issue is ready` can be confusing for maintainers (I was thinking `ready` means `ready to work on`, which is not what the tickbox wants to say, I suppose). So the PR suggested a different way to express the idea of this tickbox.

